### PR TITLE
$post->getUrlKey() instead of $post->getUrl()

### DIFF
--- a/_posts/magento2/2015-08-19-magento-2-module-from-scratch-p4-the-frontend.md
+++ b/_posts/magento2/2015-08-19-magento-2-module-from-scratch-p4-the-frontend.md
@@ -200,7 +200,7 @@ Create the file `view/frontend/templates/list.phtml`:
 <?php foreach ($block->getPosts() as $post): ?>
     <li class="blog-post-list-item">
         <h3 class="blog-post-item-title">
-            <a href="<?php echo $post->getUrl() ?>"><?php echo $post->getTitle() ?></a>
+            <a href="<?php echo $post->getUrlKey() ?>"><?php echo $post->getTitle() ?></a>
         </h3>
 
         <div class="blog-post-item-content">


### PR DESCRIPTION
$post->getUrlKey() should be instead of $post->getUrl() , because on model we have getUrlKey() function